### PR TITLE
Fixed Color int conversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ git:
   depth: 5
 
 php:
-    - 5.6
     - 7.0
-    - hhvm
 
 before_script:
     - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi;

--- a/src/Phim/Color.php
+++ b/src/Phim/Color.php
@@ -1319,41 +1319,22 @@ class Color
     public static function toInt(ColorInterface $color)
     {
 
-        if ($color instanceof AlphaColorInterface) {
-
-            $color = $color->toRgba();
-
-            return (int)(
-                + ($color->getRed() << 24)
-                + ($color->getGreen() << 16)
-                + ($color->getBlue() << 8)
-                + (int)($color->getAlpha() * 255)
-            );
-        }
-
-        $color = $color->toRgb();
-        return (int)(
-            + ($color->getRed() << 16)
-            + ($color->getGreen() << 8)
-            + $color->getBlue()
-        );
+        return unpack('N', pack('C*', 
+            $color->getRed(), 
+            $color->getGreen(), 
+            $color->getBlue(), 
+            $color instanceof AlphaColorInterface ? (int)($color->getAlpha() * 255) : 1
+        ))[1];
     }
 
     public static function parseInt($int)
     {
 
-        if ($int > 0xffffff)
-            return new RgbaColor(
-                (int)(255 & ($int >> 24)),
-                (int)(255 & ($int >> 16)),
-                (int)(255 & ($int >> 8)),
-                (int)((255 & $int) / 255)
-            );
-
-        return new RgbColor(
+        return new RgbaColor(
+            (int)(255 & ($int >> 24)),
             (int)(255 & ($int >> 16)),
             (int)(255 & ($int >> 8)),
-            (int)(255 & ($int))
+            (int)((255 & $int) / 255)
         );
     }
 

--- a/tests/unit/ColorTest.php
+++ b/tests/unit/ColorTest.php
@@ -3,42 +3,37 @@
 namespace Phim\Test;
 
 use Phim\Color;
+use PHPUnit\Framework\TestCase;
 
-class ColorTest extends \PHPUnit_Framework_TestCase
+class ColorTest extends TestCase
 {
 
     public function testFunctionStringConversion()
     {
 
         $c = Color::get('hsl(50%, 50%, 100%)')->toHsl();
-
-        $this->assertEquals(180, $c->getHue());
+        self::assertEquals(180, $c->getHue());
 
         $c = Color::get('hsl(-180, 50%, 100%)')->toHsl();
-
-        $this->assertEquals(180, $c->getHue());
+        self::assertEquals(180, $c->getHue());
 
         $c = Color::get('hsl(-150%, 50%, 100%)')->toHsl();
-
-        $this->assertEquals(180, $c->getHue());
+        self::assertEquals(180, $c->getHue());
 
         $c = Color::get('hsl(150%, 50%, 100%)')->toHsl();
-        
-        $this->assertEquals(180, $c->getHue());
-        $this->assertEquals(.5, $c->getSaturation());
-        $this->assertEquals(1.0, $c->getLightness());
+        self::assertEquals(180, $c->getHue());
+        self::assertEquals(.5, $c->getSaturation());
+        self::assertEquals(1.0, $c->getLightness());
 
         $c = Color::get('rgb(34.23%, 20%, 120)')->toRgb();
-
-        $this->assertEquals(87, $c->getRed());
-        $this->assertEquals(51, $c->getGreen());
-        $this->assertEquals(120, $c->getBlue());
+        self::assertEquals(87, $c->getRed());
+        self::assertEquals(51, $c->getGreen());
+        self::assertEquals(120, $c->getBlue());
 
         $c = Color::get('hsla(0.872664626rad, .4, 90%, 22.3%)')->toHsla();
-
-        $this->assertEquals(50, $c->getHue());
-        $this->assertEquals(.4, $c->getSaturation());
-        $this->assertEquals(.9, $c->getLightness());
-        $this->assertEquals(.223, $c->getAlpha());
+        self::assertEquals(50, $c->getHue());
+        self::assertEquals(.4, $c->getSaturation());
+        self::assertEquals(.9, $c->getLightness());
+        self::assertEquals(.223, $c->getAlpha());
     }
 }


### PR DESCRIPTION
- Color::parseInt will only return RgbaColor (0xffffff is the same as 0xffffff00 in PHP, so an RGBA color with Alpha 0 would've been seen as an RgbColor (implying full alpha))
- Color::toInt will now use pack/unpack to build the int value to avoid platform difference problems