### PR TITLE
Do not rely on correct number locale while creating rgba strings

### DIFF
--- a/src/Phim/Color/RgbaColor.php
+++ b/src/Phim/Color/RgbaColor.php
@@ -39,6 +39,7 @@ class RgbaColor extends RgbColor implements RgbaColorInterface
         $g = intval($this->green);
         $b = intval($this->blue);
         $alph = round($this->alpha, 2);
-        return "rgba({$r},{$g},{$b},{$alph})";
+
+        return sprintf("rgba(%d,%d,%d,%s)", $r, $g, $b, number_format($alph, 2, '.', null));
     }
 }

--- a/tests/unit/ColorTest.php
+++ b/tests/unit/ColorTest.php
@@ -37,6 +37,11 @@ class ColorTest extends TestCase
         self::assertEquals(.4, $c->getSaturation());
         self::assertEquals(.9, $c->getLightness());
         self::assertEquals(.223, $c->getAlpha());
+
+        setlocale(LC_NUMERIC, 'sk_SK');
+
+        $c = Color::get('rgb(10, 56, 100)')->toRgba()->setAlpha(.5);
+        self::assertEquals('rgba(10,56,100,0.50)', (string) $c);
     }
 
     public function testIntegerConversion()


### PR DESCRIPTION
Hi,
I found if you are using Phim library with locales which use comma as decimal point the string output of RgbaColor is invalid. Please check my little bugfix ;) 