### PR TITLE
fix Color::parseHexString for input of 6 characters

### DIFF
--- a/src/Phim/Color.php
+++ b/src/Phim/Color.php
@@ -1311,6 +1311,12 @@ class Color
                     hexdec($string[2].$string[2]),
                     hexdec($string[3].$string[3]) / 255
                 );
+            case 6:
+                return new RgbColor(
+                    hexdec($string[0].$string[1]),
+                    hexdec($string[2].$string[3]),
+                    hexdec($string[4].$string[5])
+                );
         }
 
         return self::parseInt(hexdec($string));

--- a/tests/unit/ColorTest.php
+++ b/tests/unit/ColorTest.php
@@ -32,6 +32,11 @@ class ColorTest extends TestCase
         self::assertEquals(51, $c->getGreen());
         self::assertEquals(120, $c->getBlue());
 
+        $c = Color::get('#6BBAA7')->toRgb();
+        self::assertEquals(107, $c->getRed());
+        self::assertEquals(186, $c->getGreen());
+        self::assertEquals(167, $c->getBlue());
+
         $c = Color::get('hsla(0.872664626rad, .4, 90%, 22.3%)')->toHsla();
         self::assertEquals(50, $c->getHue());
         self::assertEquals(.4, $c->getSaturation());


### PR DESCRIPTION
This fixes issue #5 where parsing a 6-character hex string is incorrectly parsed and results in the wrong color.

Please let me know if I can help any further.